### PR TITLE
fix: remove unused error-prone submodule setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/apk-builder"]
-	path = deps/apk-builder
-	url = https://github.com/rust-windowing/android-rs-glue


### PR DESCRIPTION
According to https://git-scm.com/docs/gitsubmodules, there must be a working directory at `path/to/bar/` if there's a `submodule.foo.path = path/to/bar` entry in `.gitmodules`. Failure to have this will result in errors in certain build environments (e.g. Flatpak: https://github.com/standardnotes/app/pull/516)

Same as in https://github.com/rust-windowing/glutin/pull/1575

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
